### PR TITLE
Load pear/mime_type from packagist rather than pear for composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,13 +16,7 @@
     "autoload": {
         "psr-0": {"": "src/"}
     },
-    "repositories": [
-        {
-            "type": "pear",
-            "url": "pear.php.net"
-        }
-    ],
     "require": {
-        "pear-pear.php.net/MIME_Type": "~1.3"
+        "pear/mime_type": "~1.3"
     }
 }


### PR DESCRIPTION
Loading pear packages with composer is slow as hell (and requires users to register the pear repository). As the package is available on Packagist directly, using it is better.
