### PR TITLE
Add the browsable source in composer metadata

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,8 @@
         }
     ],
     "support": {
+        "source": "https://github.com/cweiske/MIME_Type_PlainDetect",
+        "issues": "https://github.com/cweiske/MIME_Type_PlainDetect/issues",
         "email": "cweiske@cweiske.de"
     },
     "autoload": {


### PR DESCRIPTION
This would allow packagist to link to the source (which cannot be guessed as the repo is not registered from Github but your own repo)
